### PR TITLE
Correct misleading comment

### DIFF
--- a/multithreading/thread-local-storage.md
+++ b/multithreading/thread-local-storage.md
@@ -67,7 +67,7 @@ void worker(bool firstTime)
 void main()
 {
     // Cria 5 threads nesta chamada
-    // havendo um worker(true,i) cada.
+    // havendo um worker(true) cada.
     for (size_t i = 0; i < 5; ++i) {
         spawn(&worker, true);
     }


### PR DESCRIPTION
This PR corrects a misleading comment. At first glance, I expected `i` to be printed by worker, but it is not passed in the actual thread call.